### PR TITLE
feat: add email support via confirmed_email field

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,26 @@
 # OmniAuth::Twitter2
+
 [![test](https://github.com/unasuke/omniauth-twitter2/actions/workflows/main.yml/badge.svg)](https://github.com/unasuke/omniauth-twitter2/actions/workflows/main.yml)
 [![GitHub license](https://img.shields.io/github/license/unasuke/omniauth-twitter2)](https://github.com/unasuke/omniauth-twitter2/blob/main/LICENSE.txt)
 [![Gem Version](https://badge.fury.io/rb/omniauth-twitter2.svg)](https://rubygems.org/gems/omniauth-twitter2)
 
 This gem provides a OmniAuth strategy for authenticating with Twitter OAuth2.
 
+## Email Support
+
+As of April 2025, Twitter/X API v2 supports returning the user's email address via the `confirmed_email` field. To request the email, include the `users.email` scope:
+
+```ruby
+scope: "tweet.read users.read users.email"
+```
+
+**Note:** The email will only be returned if:
+
+1. Your Twitter app has "Request email from users" enabled in the Developer Portal
+2. The user has a confirmed email address on their Twitter account
+3. The user grants permission during OAuth
+
+If these conditions aren't met, `email` will be `nil` in the auth hash.
 
 ## Installation
 
@@ -33,7 +49,7 @@ $ gem install omniauth-twitter2
 ```ruby
 # config/initializers/omniauth.rb
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :twitter2, ENV["TWITTER_CLIENT_ID"], ENV["TWITTER_CLIENT_SECRET"], callback_path: '/auth/twitter2/callback', scope: "tweet.read users.read"
+  provider :twitter2, ENV["TWITTER_CLIENT_ID"], ENV["TWITTER_CLIENT_SECRET"], callback_path: '/auth/twitter2/callback', scope: "tweet.read users.read users.email"
 end
 ```
 
@@ -44,7 +60,7 @@ end
     "uid" => "108252390",
     "info" => {
       "name" => "うなすけ",
-      "email" => nil,
+      "email" => "user@example.com", # nil if users.email scope not granted or email not confirmed
       "nickname" => "yu_suke1994",
       "description" => "帰って寝たい",
       "image" => "https://pbs.twimg.com/profile_images/580019517608218624/KzEZSzUy_normal.jpg",
@@ -61,6 +77,7 @@ end
     "extra" => {
       "raw_info" => {
         "data" => {
+          "confirmed_email" => "user@example.com", # only present if users.email scope granted
           "profile_image_url" => "https://pbs.twimg.com/profile_images/580019517608218624/KzEZSzUy_normal.jpg",
           "url" => "https://t.co/NCFLB8wDkx",
           "public_metrics" => {
@@ -100,16 +117,17 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## References
 
-* Twitter official resources
-  * [xdevplatform/Twitter-API-v2-sample-code: Sample code for the Twitter API v2 endpoints](https://github.com/xdevplatform/Twitter-API-v2-sample-code)
-  * [OAuth 2.0 - X](https://docs.x.com/fundamentals/authentication/oauth-2-0/overview)
-* [arunagw/omniauth-twitter: OmniAuth strategy for Twitter](https://github.com/arunagw/omniauth-twitter)
-* [omniauth/omniauth-oauth2: An abstract OAuth2 strategy for OmniAuth.](https://github.com/omniauth/omniauth-oauth2)
-* [nov/twitter_oauth2: Twitter OAuth 2.0 Client Library in Ruby](https://github.com/nov/twitter_oauth2)
+- Twitter official resources
+  - [xdevplatform/Twitter-API-v2-sample-code: Sample code for the Twitter API v2 endpoints](https://github.com/xdevplatform/Twitter-API-v2-sample-code)
+  - [OAuth 2.0 - X](https://docs.x.com/fundamentals/authentication/oauth-2-0/overview)
+- [arunagw/omniauth-twitter: OmniAuth strategy for Twitter](https://github.com/arunagw/omniauth-twitter)
+- [omniauth/omniauth-oauth2: An abstract OAuth2 strategy for OmniAuth.](https://github.com/omniauth/omniauth-oauth2)
+- [nov/twitter_oauth2: Twitter OAuth 2.0 Client Library in Ruby](https://github.com/nov/twitter_oauth2)
 
 ## Sample App
-* <https://twitter-login-app.onrender.com/>
-  * <https://github.com/unasuke/twitter-login-app>
+
+- <https://twitter-login-app.onrender.com/>
+  - <https://github.com/unasuke/twitter-login-app>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ This gem provides a OmniAuth strategy for authenticating with Twitter OAuth2.
 
 ## Email Support
 
-As of April 2025, Twitter/X API v2 supports returning the user's email address via the `confirmed_email` field. To request the email, include the `users.email` scope:
+As of April 2025, Twitter/X API v2 supports returning the user's email address via the `confirmed_email` field. See the [X Developer Community announcement](https://devcommunity.x.com/t/introducing-confirmed-email-in-user-object/233461).
+
+To request the email, include the `users.email` scope:
 
 ```ruby
 scope: "tweet.read users.read users.email"
@@ -117,17 +119,17 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## References
 
-- Twitter official resources
-  - [xdevplatform/Twitter-API-v2-sample-code: Sample code for the Twitter API v2 endpoints](https://github.com/xdevplatform/Twitter-API-v2-sample-code)
-  - [OAuth 2.0 - X](https://docs.x.com/fundamentals/authentication/oauth-2-0/overview)
-- [arunagw/omniauth-twitter: OmniAuth strategy for Twitter](https://github.com/arunagw/omniauth-twitter)
-- [omniauth/omniauth-oauth2: An abstract OAuth2 strategy for OmniAuth.](https://github.com/omniauth/omniauth-oauth2)
-- [nov/twitter_oauth2: Twitter OAuth 2.0 Client Library in Ruby](https://github.com/nov/twitter_oauth2)
+* Twitter official resources
+  * [xdevplatform/Twitter-API-v2-sample-code: Sample code for the Twitter API v2 endpoints](https://github.com/xdevplatform/Twitter-API-v2-sample-code)
+  * [OAuth 2.0 - X](https://docs.x.com/fundamentals/authentication/oauth-2-0/overview)
+* [arunagw/omniauth-twitter: OmniAuth strategy for Twitter](https://github.com/arunagw/omniauth-twitter)
+* [omniauth/omniauth-oauth2: An abstract OAuth2 strategy for OmniAuth.](https://github.com/omniauth/omniauth-oauth2)
+* [nov/twitter_oauth2: Twitter OAuth 2.0 Client Library in Ruby](https://github.com/nov/twitter_oauth2)
 
 ## Sample App
 
-- <https://twitter-login-app.onrender.com/>
-  - <https://github.com/unasuke/twitter-login-app>
+* <https://twitter-login-app.onrender.com/>
+  * <https://github.com/unasuke/twitter-login-app>
 
 ## Contributing
 

--- a/lib/omniauth/strategies/twitter2.rb
+++ b/lib/omniauth/strategies/twitter2.rb
@@ -20,7 +20,7 @@ module OmniAuth
       info do
         {
           name: raw_info["data"]["name"],
-          email: nil,
+          email: raw_info["data"]["confirmed_email"],
           nickname: raw_info["data"]["username"],
           description: raw_info["data"]["description"],
           image: raw_info["data"]["profile_image_url"],
@@ -38,7 +38,7 @@ module OmniAuth
       def raw_info
         @raw_info ||= access_token.get(
           "/2/users/me?" \
-          "&user.fields=created_at,description,entities,id,location,name,pinned_tweet_id," \
+          "user.fields=confirmed_email,created_at,description,entities,id,location,name,pinned_tweet_id," \
           "profile_image_url,protected,public_metrics,url,username,verified,withheld",
           { headers: { "Authorization" => "Bearer #{access_token.token}" } }
         ).parsed || {}

--- a/test/omniauth/test_twitter2.rb
+++ b/test/omniauth/test_twitter2.rb
@@ -18,7 +18,7 @@ class TestOmniAuthTwitter2 < Minitest::Test
   end
 
   def test_that_it_has_a_version_number
-    refute_nil ::OmniAuth::Twitter2::VERSION
+    assert ::OmniAuth::Twitter2::VERSION
   end
 
   def test_it_has_strategy_name_twitter2
@@ -41,9 +41,18 @@ class TestOmniAuthTwitter2 < Minitest::Test
     subject = strategy
     subject.stub(:raw_info, raw_info_sample) do
       assert_equal "うなすけ", subject.info[:name]
-      assert_nil subject.info[:email]
+      assert_equal "user@example.com", subject.info[:email]
       assert_equal "yu_suke1994", subject.info[:nickname]
       assert_equal "帰って寝たい", subject.info[:description]
+    end
+  end
+
+  def test_email_is_nil_when_not_provided
+    subject = strategy
+    raw_info_without_email = raw_info_sample.dup
+    raw_info_without_email["data"] = raw_info_without_email["data"].except("confirmed_email")
+    subject.stub(:raw_info, raw_info_without_email) do
+      assert_nil subject.info[:email]
     end
   end
 

--- a/test/omniauth/test_twitter2.rb
+++ b/test/omniauth/test_twitter2.rb
@@ -50,7 +50,7 @@ class TestOmniAuthTwitter2 < Minitest::Test
   def test_email_is_nil_when_not_provided
     subject = strategy
     raw_info_without_email = raw_info_sample.dup
-    raw_info_without_email["data"] = raw_info_without_email["data"].except("confirmed_email")
+    raw_info_without_email["data"] = raw_info_without_email["data"].tap { |h| h.delete("confirmed_email") }
     subject.stub(:raw_info, raw_info_without_email) do
       assert_nil subject.info[:email]
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ def mock_auth_sample # rubocop:disable Metrics/MethodLength
     "uid" => "108252390",
     "info" => {
       "name" => "うなすけ",
-      "email" => nil,
+      "email" => "user@example.com",
       "nickname" => "yu_suke1994",
       "description" => "帰って寝たい",
       "image" => "https://pbs.twimg.com/profile_images/580019517608218624/KzEZSzUy_normal.jpg",
@@ -33,6 +33,7 @@ end
 def raw_info_sample # rubocop:disable Metrics/MethodLength
   {
     "data" => {
+      "confirmed_email" => "user@example.com",
       "profile_image_url" => "https://pbs.twimg.com/profile_images/580019517608218624/KzEZSzUy_normal.jpg",
       "url" => "https://t.co/NCFLB8wDkx",
       "public_metrics" => {


### PR DESCRIPTION
## Summary

This PR adds support for retrieving the user's email address from Twitter/X API v2.

As of April 2025, Twitter/X added the `confirmed_email` field to their API v2 user endpoint. This PR:

1. Adds `confirmed_email` to the `user.fields` request parameter
2. Maps `confirmed_email` to the standard `email` field in the info hash
3. Updates the README with documentation on email support

## Changes

- Modified `lib/omniauth/strategies/twitter2.rb` to request and map `confirmed_email`
- Updated README.md with:
  - New "Email Support" section explaining the feature and requirements
  - Updated example scope to include `users.email`
  - Updated Auth Hash example showing email with a value
  - Added `confirmed_email` to the raw_info example

## Usage

Users need to:
1. Enable "Request email from users" in their Twitter Developer Portal app settings
2. Include `users.email` in their OAuth scope
3. Handle the case where email may still be `nil` if the user hasn't confirmed their email

## Test plan

- [x] Tested manually with a Twitter OAuth flow - email is now correctly returned when the scope is granted