### PR TITLE
Add minitest-mock dependency for Ruby 3.1+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,5 @@ gemspec
 gem "minitest"
 gem "rake"
 gem "rubocop"
+
+gem "minitest-mock" if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create("3.1")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "omniauth/twitter2"
 
+require "minitest/mock"
 require "minitest/autorun"
 
 def mock_auth_sample # rubocop:disable Metrics/MethodLength


### PR DESCRIPTION
## What
minitest-mock was extracted from minitest core in Ruby 3.1, so it needs to be added as a separate dependency for newer Ruby versions.

https://github.com/minitest/minitest/blob/v6.0.0/History.rdoc#label-6.0.0+-2F+2025-12-17